### PR TITLE
Ensure quantifier dropdown shows current value

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -142,6 +142,7 @@ function updateQuantifierSelect() {
     select.appendChild(option);
   }
   quantifier = Math.min(quantifier, getCurrentList().length);
+  select.value = quantifier;
 }
 
 function updateListSelector() {


### PR DESCRIPTION
## Summary
- keep quantifier dropdown synced with internal variable in `updateQuantifierSelect`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684b2ead57c08328a14afdc546a2a20f