### PR TITLE
Adjust mobile layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -53,6 +53,12 @@ select, input[type="text"] {
   border-radius: 0.5em;
   margin: 0.5em 0;
 }
+textarea,
+#pageTitleInput {
+  width: 100%;
+  box-sizing: border-box;
+}
+
 
 ul {
   font-size: 18pt;
@@ -89,8 +95,12 @@ ul li {
   }
   button,
   select,
-  input[type="text"] {
+  input[type="text"],
+  input[type="file"] {
+    width: auto;
+    margin: 0.25em;
+  }
+  textarea {
     width: 100%;
-    margin: 0.5em 0;
   }
 }

--- a/index.html
+++ b/index.html
@@ -31,7 +31,6 @@
 
   <h3>Listen Exportieren/Importieren</h3>
   <textarea id="jsonArea" rows="10" cols="50" placeholder="JSON-Daten hier einfügen oder kopieren"></textarea><br>
-  <br><br>
   <input type="file" id="fileInput" onchange="uploadBackupFile(event)">
   <button onclick="downloadBackupFile()">Backup speichern</button>
   <button onclick="exportToCSV()">CSV-Export</button>


### PR DESCRIPTION
## Summary
- keep full-width for textarea and page title input
- remove extra spacing after textarea
- shrink button, select and input widths on small screens

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684b3b7ace80832891249a27e8c79a2e