### PR TITLE
Add responsive list button layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -69,6 +69,21 @@ ul li {
   margin: 0.3em 0;
 }
 
+#list li {
+  display: flex;
+  align-items: center;
+  gap: 0.5em;
+}
+
+#list li .entry {
+  flex-grow: 1;
+}
+
+#list li .actions {
+  display: flex;
+  gap: 0.5em;
+}
+
 
 #resultList li {
   display: flex;
@@ -102,5 +117,9 @@ ul li {
   }
   textarea {
     width: 100%;
+  }
+  #list li {
+    flex-direction: column;
+    align-items: flex-start;
   }
 }

--- a/js/main.js
+++ b/js/main.js
@@ -73,12 +73,26 @@ function addStudent(student) {
 
 function showList() {
   const list = getCurrentList();
-  const listHTML = "<ul>" + list.map((e, i) => (
-    "<li>" + e +
-    " <button onclick='editStudent(" + i + ")'>✏️</button>" +
-    " <button onclick='removeStudent(" + i + ")'>🗑️</button>" +
-    "</li>"
-  )).join("") + "</ul>";
+  const listHTML =
+    "<ul>" +
+    list
+      .map(
+        (e, i) =>
+          "<li>" +
+          "<span class='entry'>" +
+          e +
+          "</span>" +
+          "<span class='actions'>" +
+          "<button onclick='editStudent(" +
+          i +
+          ")'>✏️</button>" +
+          " <button onclick='removeStudent(" +
+          i +
+          ")'>🗑️</button>" +
+          "</span></li>"
+      )
+      .join("") +
+    "</ul>";
   document.getElementById("list").innerHTML = listHTML;
   document.getElementById("headList").textContent = "Zur Auswahl (" + list.length + ")";
 }
@@ -344,12 +358,26 @@ function enableSorting() {
 
 function showList() {
   const list = getCurrentList();
-  const listHTML = "<ul>" + list.map((e, i) => (
-    "<li draggable='true'>" + e +
-    " <button onclick='editStudent(" + i + ")'>✏️</button>" +
-    " <button onclick='removeStudent(" + i + ")'>🗑️</button>" +
-    "</li>"
-  )).join("") + "</ul>";
+  const listHTML =
+    "<ul>" +
+    list
+      .map(
+        (e, i) =>
+          "<li draggable='true'>" +
+          "<span class='entry'>" +
+          e +
+          "</span>" +
+          "<span class='actions'>" +
+          "<button onclick='editStudent(" +
+          i +
+          ")'>✏️</button>" +
+          " <button onclick='removeStudent(" +
+          i +
+          ")'>🗑️</button>" +
+          "</span></li>"
+      )
+      .join("") +
+    "</ul>";
   document.getElementById("list").innerHTML = listHTML;
   document.getElementById("headList").textContent = "Zur Auswahl (" + list.length + ")";
   enableSorting();


### PR DESCRIPTION
## Summary
- add `.entry` and `.actions` wrappers in `showList` output
- style `#list li` buttons to wrap below student names on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684b3cde373c83288be649591073b43f